### PR TITLE
Add release key to configuration

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,6 +18,7 @@ type Option func(o *option)
 type option struct {
 	stage        string
 	sentryDns    string
+	release      string
 	sentryTags   map[string]string
 	sentrtFields []zapcore.Field
 }
@@ -38,6 +39,12 @@ func WithSentry(sentryDNS string, tags map[string]string, fields []zapcore.Field
 func WithStage(stage string) Option {
 	return func(o *option) {
 		o.stage = stage
+	}
+}
+
+func WithRelease(release string) Option {
+	return func(o *option) {
+		o.release = release
 	}
 }
 
@@ -66,8 +73,9 @@ func createLoagger(o *option) *zap.Logger {
 	}
 
 	cfg := Configuration{
-		DSN:  o.sentryDns,
-		Tags: o.sentryTags,
+		DSN:     o.sentryDns,
+		Tags:    o.sentryTags,
+		Release: o.release,
 	}
 
 	sentryCore, err := cfg.Build()

--- a/sentry.go
+++ b/sentry.go
@@ -40,9 +40,10 @@ type client interface {
 
 // Configuration is a minimal set of parameters for Sentry integration.
 type Configuration struct {
-	DSN   string `yaml:"DSN"`
-	Tags  map[string]string
-	Trace trace
+	DSN     string `yaml:"DSN"`
+	Tags    map[string]string
+	Trace   trace
+	Release string
 }
 
 type trace struct {
@@ -56,6 +57,7 @@ func (c Configuration) Build() (zapcore.Core, error) {
 	if err != nil {
 		return zapcore.NewNopCore(), err
 	}
+	client.SetRelease(c.Release)
 	return newCore(c, client, zapcore.ErrorLevel), nil
 }
 


### PR DESCRIPTION
Hi,

I want to add the `Release` key when building the Sentry-backed logging. It makes the Sentry dashboard contains the release I want.